### PR TITLE
Fish Compatibility

### DIFF
--- a/files/foreman.fish
+++ b/files/foreman.fish
@@ -1,0 +1,3 @@
+# Add Foreman bins to PATH
+
+set -gx PATH "$BOXEN_HOME/foreman/bin" $PATH

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,10 +41,11 @@ class foreman(
       }
 
       boxen::env_script { 'foreman-fish':
-        ensure    => $ensure,
-        priority  => 'lower',
-        source    => 'puppet:///modules/foreman/foreman.fish',
-        extension => 'fish'
+        ensure     => $ensure,
+        priority   => 'lower',
+        scriptname => 'foreman',
+        source     => 'puppet:///modules/foreman/foreman.fish',
+        extension  => 'fish'
       }
 
       boxen::env_script { 'foreman':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,11 +41,12 @@ class foreman(
       }
 
       boxen::env_script { 'foreman-fish':
-        ensure   => $ensure,
-        priority => 'lower',
-        source   => 'puppet:///modules/foreman/foreman.fish',
+        ensure    => $ensure,
+        priority  => 'lower',
+        source    => 'puppet:///modules/foreman/foreman.fish',
+        extension => 'fish'
       }
-      
+
       boxen::env_script { 'foreman':
         ensure   => $ensure,
         priority => 'lower',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -40,6 +40,12 @@ class foreman(
         ensure => absent,
       }
 
+      boxen::env_script { 'foreman-fish':
+        ensure   => $ensure,
+        priority => 'lower',
+        source   => 'puppet:///modules/foreman/foreman.fish',
+      }
+      
       boxen::env_script { 'foreman':
         ensure   => $ensure,
         priority => 'lower',


### PR DESCRIPTION
Adds a fish version of the env script.

Relies on boxen/puppet-boxen#138 (for the `extension` argument to `env_script`)
